### PR TITLE
Chore/backend fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "chai": "^3.3.0",
     "colors": "^1.1.2",
     "express": "^4.13.3",
-    "express-redis-cache": "^0.1.8",
+    "express-redis-cache": "LOLQueen/express-redis-cache",
     "hiredis": "^0.4.1",
     "nodemon": "^1.7.1",
     "ramda": "^0.18.0",

--- a/routes/matches/index.js
+++ b/routes/matches/index.js
@@ -11,9 +11,13 @@ import {handleError, makeRouter} from 'utils';
 import {map, propEq, clone, __, prop, compose, pluck, chain, objOf, merge}
 from 'ramda';
 
+import {cache} from 'services/RedisCache';
+
 let router = makeRouter();
 
-router.get('/', async function(request, response){
+router.get('/',
+  cache({type: 'application/json'}), 
+  async function(request, response) {
   const region = request.params.region;
   const summonerId = request.query['summoner-id'];
 

--- a/services/RIOTApi/index.js
+++ b/services/RIOTApi/index.js
@@ -3,6 +3,8 @@ import {fetchStaticFromRiot, fetchFromRiot} from './core';
 import {
   transformChampion,
   transformSummoner,
+  transformSpell,
+  transformItem,
 } from './transforms';
 
 import {
@@ -18,7 +20,6 @@ import {
 } from 'ramda';
 
 const intoFourties = compose(splitEvery(40), uniq);
-const reindex = partial(reindexWith, [x => x]);
 
 async function reindexWith (fn, key, data) {
   return values(data).reduce(async (map, item) => (
@@ -52,17 +53,19 @@ export async function fetchChampions({region}) {
 }
 
 async function fetchSpells({region}) {
-  return reindex(
-    'id', await fetchStaticFromRiot({
+  return reindexWith(
+    transformSpell, 'id', await fetchStaticFromRiot({
       region, url: `v1.2/summoner-spell`
     })
   );
 }
 
 async function fetchItems({region}) {
-  return await fetchStaticFromRiot({
-    region, url: `v1.2/item`
-  });
+  return reindexWith(
+    transformItem, 'id', await fetchStaticFromRiot({
+      region, url: `v1.2/item`
+    })
+  );
 }
 
 export async function fetchSummoner({region, id}) {

--- a/services/RIOTApi/transforms.js
+++ b/services/RIOTApi/transforms.js
@@ -18,3 +18,15 @@ export async function transformSummoner(summoner) {
     level: summoner.summonerLevel,
   };
 }
+
+export async function transformItem(item) {
+  return merge(item, {
+    imageUrl: `${DRAGON_URL}/item/${item.id}.png`,
+  });
+}
+
+export async function transformSpell(spell) {
+  return merge(spell, {
+    imageUrl: `${DRAGON_URL}/spell/${spell.key}.png`,
+  });
+}


### PR DESCRIPTION
Changes:
- fixes express-redis-cache
- caches /matches route
- decorates spells and items payload with image urls
