### PR TITLE
Fixing error wherein playing with bots leads the back-end to crash.

### DIFF
--- a/services/RIOTApi/transforms/games.js
+++ b/services/RIOTApi/transforms/games.js
@@ -6,7 +6,7 @@ import {
   fetchSummoners,
 } from 'services/RIOTApi';
 
-import { propEq, clone, compose, pluck, chain, merge, map } from 'ramda';
+import { propEq, clone, compose, pluck, chain, merge, map, filter } from 'ramda';
 
 const isTeamPurple = propEq('teamId', 200);
 const isTeamBlue = propEq('teamId', 100);
@@ -47,17 +47,17 @@ function transformGameToMatch(region) {
 
 const extractSummonerIds = compose(
   chain(pluck('summonerId')),
+  filter(Boolean),
   pluck('fellowPlayers')
 );
 
 async function transformPlayersInGames(region, games) {
   const summonerIds = extractSummonerIds(games);
-
   const summoners = await fetchSummoners({ region, ids: summonerIds });
   const champions = await fetchChampions({ region });
 
   return games.map((game) => {
-    const fellowPlayers = game.fellowPlayers;
+    const { fellowPlayers = [] } = game;
     return merge(game, {
       fellowPlayers: fellowPlayers.map((player) => {
         return player && {


### PR DESCRIPTION
When playing with the bots, the `fellowPlayers` array returned by riot doesn't exist (i.e: it's not empty). This was causing us to map over undefined, which was throwing errors. 
